### PR TITLE
docs: add missing shortcut instruction of kubectl

### DIFF
--- a/docs/Installation/installation-microk8s.md
+++ b/docs/Installation/installation-microk8s.md
@@ -17,13 +17,15 @@ Optional but recommended:
 microk8s enable metrics-server cert-manager
 ```
 
-extract your kubeconfig and switch the context to this config
+Extract your kubeconfig and switch the context to this config
 ```bash
 microk8s config > ~/.kube/config
 kubectl config use-context microk8s
 ```
 
-find the IP of the ingress controller
+> For shortcut, use alias k = kubectl
+
+Find the IP of the ingress controller
 ```bash
 k get nodes -o wide
 ```


### PR DESCRIPTION
We had a discussion over the installation support of different k8 flavor at https://github.com/kubero-dev/kubero/issues/330. While observing the installation section of microk8s.

I saw using ```k`` directly without giving the context for the developer. Not everyone knows that it used alias behind it. For giving more context, I add instruction so ```k get nodes -o wide``` works fine at the command line else it will raise an error.

cc @mms-gianni 